### PR TITLE
prevent an infinite recursion prefersStatusBarHidden() 

### DIFF
--- a/KRProgressHUD/Classes/KRProgressHUDViewController.swift
+++ b/KRProgressHUD/Classes/KRProgressHUDViewController.swift
@@ -15,6 +15,9 @@ class KRProgressHUDViewController: UIViewController {
 
     override func prefersStatusBarHidden() -> Bool {
         guard let vc = UIApplication.topViewController() else { return false }
+        if vc.isKindOfClass(KRProgressHUDViewController) {
+            return false
+        }
         return vc.prefersStatusBarHidden()
     }
 }


### PR DESCRIPTION
The code below will cause infinite recursion.

        dispatch_after(delay, dispatch_get_main_queue()) {

            KRProgressHUD.dismiss()

            let alert = UIAlertController(title: "Hello" , message: "", preferredStyle: .Alert)
            alert.addAction(UIAlertAction(title: "ok", style: .Default, handler: nil))
            self.presentViewController(alert, animated: true) {
                
            }
        }

So, I add the code to prevent this issue.