### PR TITLE
Fix HUD position after screen rotation

### DIFF
--- a/KRProgressHUD/Classes/InnerKRProgressHUD.swift
+++ b/KRProgressHUD/Classes/InnerKRProgressHUD.swift
@@ -24,9 +24,10 @@ fileprivate let messageLabelFrame = CGRect(x: messageLabelMargin,
 extension KRProgressHUD {
    func configureProgressHUDView() {
       window.windowLevel = UIWindowLevelNormal
+      defaultViewCenterPosition = CGPoint(x: window.bounds.midX, y: window.bounds.midY)
 
       hudView.frame.size = hudSize
-      hudView.center = viewAppearance.viewCenterPosition
+      hudView.center = defaultViewCenterPosition
       hudView.backgroundColor = .white
       hudView.layer.cornerRadius = 10
       hudView.autoresizingMask = [.flexibleTopMargin, .flexibleBottomMargin,
@@ -167,8 +168,10 @@ extension KRProgressHUD {
    }
 
    func resetLayouts() {
+      hudViewController.view.frame = window.frame
+      defaultViewCenterPosition = CGPoint(x: window.bounds.midX, y: window.bounds.midY)
       hudView.frame.size = hudSize
-      hudView.center = viewCenterPosition ?? viewAppearance.viewCenterPosition
+      hudView.center = viewCenterPosition ?? defaultViewCenterPosition
       iconView.isHidden = false
       iconView.center = iconViewCenter
       activityIndicatorView.stopAnimating()
@@ -193,14 +196,14 @@ extension KRProgressHUD {
          messageLabel.frame.origin = CGPoint(x: messageLabelMargin, y: messageLabelMargin)
          hudView.frame.size = CGSize(width: messageLabel.bounds.width + messageLabelMargin*2,
                                      height: messageLabel.bounds.height + messageLabelMargin*2)
-         hudView.center = viewCenterPosition ?? viewAppearance.viewCenterPosition
+         hudView.center = viewCenterPosition ?? defaultViewCenterPosition
          return
       }
 
       if message == nil {
          messageLabel.isHidden = true
          hudView.frame.size = simpleHUDSize
-         hudView.center = viewCenterPosition ?? viewAppearance.viewCenterPosition
+         hudView.center = viewCenterPosition ?? defaultViewCenterPosition
          iconView.center = simpleHUDIconViewCenter
       }
 

--- a/KRProgressHUD/Classes/KRProgressHUD.swift
+++ b/KRProgressHUD/Classes/KRProgressHUD.swift
@@ -80,8 +80,6 @@ public final class KRProgressHUD {
       public var activityIndicatorStyle = KRActivityIndicatorViewStyle.gradationColor(head: .black, tail: .lightGray)
       /// Default message label font.
       public var font = UIFont.systemFont(ofSize: 13)
-      /// Default HUD center position.
-      public var viewCenterPosition = CGPoint(x: UIScreen.main.bounds.width/2, y: UIScreen.main.bounds.height/2)
       /// Default time to show HUD.
       public var deadlineTime = Double(1.0)
 
@@ -107,6 +105,7 @@ public final class KRProgressHUD {
    var maskType: KRProgressHUDMaskType?
    var activityIndicatorStyle: KRActivityIndicatorViewStyle?
    var font: UIFont?
+   var defaultViewCenterPosition: CGPoint!
    var viewCenterPosition: CGPoint?
    var deadlineTime: Double?
 

--- a/KRProgressHUDTests/KRProgressHUDTests.swift
+++ b/KRProgressHUDTests/KRProgressHUDTests.swift
@@ -91,6 +91,12 @@ class KRProgressHUDTests: XCTestCase {
        */
       XCTAssertEqual(KRProgressHUD.shared.hudView.center, centerPosition)
       
+      /**
+       Set default center position test
+       */
+    
+      KRProgressHUD.shared.defaultViewCenterPosition = CGPoint(x: 100, y: 100)
+    
       // loading
       KRProgressHUD.shared.updateLayouts(message: nil, iconType: nil, image: nil, imageSize: nil, isOnlyText: false)
       XCTAssertEqual(KRProgressHUD.shared.hudView.center, CGPoint(x: 100, y: 100))

--- a/KRProgressHUDTests/KRProgressHUDTests.swift
+++ b/KRProgressHUDTests/KRProgressHUDTests.swift
@@ -92,10 +92,10 @@ class KRProgressHUDTests: XCTestCase {
       XCTAssertEqual(KRProgressHUD.shared.hudView.center, centerPosition)
       
       /**
-       Set default center position test
+       Set window size
        */
-    
-      KRProgressHUD.shared.defaultViewCenterPosition = CGPoint(x: 100, y: 100)
+      KRProgressHUD.shared.window.bounds.size.width = 200
+      KRProgressHUD.shared.window.bounds.size.height = 200
     
       // loading
       KRProgressHUD.shared.updateLayouts(message: nil, iconType: nil, image: nil, imageSize: nil, isOnlyText: false)

--- a/KRProgressHUDTests/KRProgressHUDTests.swift
+++ b/KRProgressHUDTests/KRProgressHUDTests.swift
@@ -91,11 +91,6 @@ class KRProgressHUDTests: XCTestCase {
        */
       XCTAssertEqual(KRProgressHUD.shared.hudView.center, centerPosition)
       
-      /**
-       Set appearance test
-       */
-      KRProgressHUD.appearance().viewCenterPosition = CGPoint(x: 100, y: 100)
-      
       // loading
       KRProgressHUD.shared.updateLayouts(message: nil, iconType: nil, image: nil, imageSize: nil, isOnlyText: false)
       XCTAssertEqual(KRProgressHUD.shared.hudView.center, CGPoint(x: 100, y: 100))


### PR DESCRIPTION
# English
## Problem
* Unnatural HUD Position after screen rotation
## Solution
* Set the frame of hudViewController to the frame of UIWindow when resetLayout is called
* Since the centerPosition was not changed after rotating the screen
To change centerPosition when resetLayout is called

## ScreenShot
![portraitposition](https://user-images.githubusercontent.com/10655747/34323885-51330ff0-e89f-11e7-90c5-0415d7ecbca0.gif)

![landscapeposition](https://user-images.githubusercontent.com/10655747/34323888-5c6216dc-e89f-11e7-9a31-1522869065f3.gif)

# 日本語
## 問題
* 画面回転後のHUD表示位置が不自然だった（スクリーンショットを参照してください）
## 解決方法
* hudViewControllerのframeが画面回転後に正しく設定されていなかったのでresetLayout時に設定するように変更
* 画面回転してもcenterPositionが変更されていなかったので反映されるように変更
